### PR TITLE
Don't steal focus from other plugins

### DIFF
--- a/EnmityHp/EnmityHp.cs
+++ b/EnmityHp/EnmityHp.cs
@@ -160,7 +160,8 @@ namespace EnmityHp
             ImGui.PushStyleVar(ImGuiStyleVar.WindowMinSize, new Vector2(0f, 0f));
             ImGui.Begin("##enmityhp" + y, ImGuiWindowFlags.NoInputs | ImGuiWindowFlags.NoScrollbar
                 | ImGuiWindowFlags.AlwaysAutoResize | ImGuiWindowFlags.NoMouseInputs | ImGuiWindowFlags.NoNavFocus
-                | ImGuiWindowFlags.AlwaysUseWindowPadding | ImGuiWindowFlags.NoTitleBar | ImGuiWindowFlags.NoSavedSettings);
+                | ImGuiWindowFlags.AlwaysUseWindowPadding | ImGuiWindowFlags.NoTitleBar | ImGuiWindowFlags.NoSavedSettings 
+                | ImGuiWindowFlags.NoFocusOnAppearing);
             ImGui.SetWindowFontScale(Cfg.Size);
             if (Cfg.Color != null)
             {


### PR DESCRIPTION
Anytime you enter combat, this spawns a window which takes focus from other plugins like Chat2 and Wotsit.
So setting the `NoFocusOnAppearing` flag is necessary to prevent this from happening.